### PR TITLE
Ignore XML errors about the "map" prefix

### DIFF
--- a/src/main/res/layout/share_locaction_activity.xml
+++ b/src/main/res/layout/share_locaction_activity.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:map="http://schemas.android.com/apk/res-auto"
+                xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="@color/primarybackground">
@@ -17,7 +18,7 @@
         map:uiTiltGestures="false"
         map:uiZoomControls="false"
         map:uiZoomGestures="true"
-        />
+        tools:ignore="MissingPrefix"/>
 
     <RelativeLayout
         android:id="@+id/snackbar"

--- a/src/main/res/layout/show_locaction_activity.xml
+++ b/src/main/res/layout/show_locaction_activity.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:map="http://schemas.android.com/apk/res-auto"
+                xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
@@ -17,6 +18,6 @@
         map:uiTiltGestures="false"
         map:uiZoomControls="false"
         map:uiZoomGestures="true"
-        />
+        tools:ignore="MissingPrefix"/>
 
 </RelativeLayout>


### PR DESCRIPTION
Make the build shutup about the missing "map" prefix (which, at least on my end, is an error and breaks the build for some strange reason).

There's probably a more "correct" way to fix this, but I couldn't find what I needed to import to actually make it recognize the prefix.